### PR TITLE
v1.3.0

### DIFF
--- a/.github/workflows/compile.yaml
+++ b/.github/workflows/compile.yaml
@@ -6,6 +6,8 @@ permissions:
 
 on:
   push:
+    branches:
+      - '*'
     tags-ignore:
       - '*'
   pull_request:

--- a/.github/workflows/compile.yaml
+++ b/.github/workflows/compile.yaml
@@ -6,6 +6,8 @@ permissions:
 
 on:
   push:
+    tags-ignore:
+      - '*'
   pull_request:
   workflow_dispatch:
   release:

--- a/CYD-Klipper/boards/esp32-3248S035C.json
+++ b/CYD-Klipper/boards/esp32-3248S035C.json
@@ -19,7 +19,7 @@
         "-DLOAD_FONT2=1",
         "-DLOAD_GFXFF=1",
         "-DSMOOTH_FONT=1",
-        "-DSPI_FREQUENCY=55000000",
+        "-DSPI_FREQUENCY=80000000",
         "-DSPI_READ_FREQUENCY=20000000",
         "-DSPI_TOUCH_FREQUENCY=2500000",
         "-DTOUCH_CS=-1",

--- a/CYD-Klipper/src/conf/global_config.h
+++ b/CYD-Klipper/src/conf/global_config.h
@@ -3,12 +3,12 @@
 
 #include "lvgl.h"
 
-#define CONFIG_VERSION 3
+#define CONFIG_VERSION 4
 
 typedef struct _GLOBAL_CONFIG {
     unsigned char version;
     union {
-        unsigned char raw;
+        unsigned int raw;
         struct {
             // Internal
             bool screenCalibrated : 1;

--- a/CYD-Klipper/src/conf/global_config.h
+++ b/CYD-Klipper/src/conf/global_config.h
@@ -20,6 +20,7 @@ typedef struct _GLOBAL_CONFIG {
             bool invertColors : 1;
             bool rotateScreen : 1;
             bool onDuringPrint : 1;
+            bool autoOtaUpdate : 1;
         };
     };
     float screenCalXOffset;

--- a/CYD-Klipper/src/conf/lv_conf.h
+++ b/CYD-Klipper/src/conf/lv_conf.h
@@ -363,7 +363,7 @@
 #define LV_FONT_CUSTOM_DECLARE
 
 /*Always set a default font*/
-#define LV_FONT_DEFAULT &lv_font_montserrat_14
+#define LV_FONT_DEFAULT &CYD_SCREEN_FONT
 
 /*Enable handling large font and/or fonts with a lot of characters.
  *The limit depends on the font size, font face and bpp.

--- a/CYD-Klipper/src/core/device/ESP32-2432S028R.cpp
+++ b/CYD-Klipper/src/core/device/ESP32-2432S028R.cpp
@@ -77,14 +77,14 @@ void touchscreen_calibrate(bool force)
     tft.drawFastHLine(300, 230, 20, ILI9341_BLACK);
     tft.drawFastVLine(310, 220, 20, ILI9341_BLACK);
 
-    int16_t xDist = 320 - 40;
-    int16_t yDist = 240 - 40;
+    int16_t xDist = 320 - 20;
+    int16_t yDist = 240 - 20;
 
     global_config.screenCalXMult = (float)xDist / (float)(x2 - x1);
-    global_config.screenCalXOffset = 20.0 - ((float)x1 * global_config.screenCalXMult);
+    global_config.screenCalXOffset = 10.0 - ((float)x1 * global_config.screenCalXMult);
 
     global_config.screenCalYMult = (float)yDist / (float)(y2 - y1);
-    global_config.screenCalYOffset = 20.0 - ((float)y1 * global_config.screenCalYMult);
+    global_config.screenCalYOffset = 10.0 - ((float)y1 * global_config.screenCalYMult);
 
     global_config.screenCalibrated = true;
     WriteGlobalConfig();

--- a/CYD-Klipper/src/core/lv_setup.cpp
+++ b/CYD-Klipper/src/core/lv_setup.cpp
@@ -1,6 +1,7 @@
 #include "lv_setup.h"
 #include "screen_driver.h"
 #include "../conf/global_config.h"
+#include "lvgl.h"
 #include <Esp.h>
 
 #ifndef CPU_FREQ_HIGH
@@ -10,9 +11,10 @@
 #define CPU_FREQ_LOW 80
 #endif
 
+typedef void (*lv_indev_drv_read_cb_t)(struct _lv_indev_drv_t * indev_drv, lv_indev_data_t * data);
+
 bool isScreenInSleep = false;
 lv_timer_t *screenSleepTimer;
-static lv_style_t default_label_style;
 
 void set_screen_brightness()
 {
@@ -120,9 +122,6 @@ void lv_touch_intercept(lv_indev_drv_t *indev_driver, lv_indev_data_t *data)
 
 void lv_setup()
 {
-    lv_style_init(&default_label_style);
-    lv_style_set_text_font(&default_label_style, &CYD_SCREEN_FONT);
-
     screen_timer_setup();
     screen_timer_start();
     set_color_scheme();
@@ -138,9 +137,4 @@ void lv_setup()
 bool is_screen_asleep()
 {
     return isScreenInSleep;
-}
-
-lv_style_t * get_default_label_style()
-{
-    return &default_label_style;
 }

--- a/CYD-Klipper/src/core/lv_setup.h
+++ b/CYD-Klipper/src/core/lv_setup.h
@@ -1,9 +1,5 @@
 #pragma once
 
-#include "lvgl.h"
-
-typedef void (*lv_indev_drv_read_cb_t)(struct _lv_indev_drv_t * indev_drv, lv_indev_data_t * data);
-
 void set_screen_brightness();
 void set_screen_timer_period();
 void screen_timer_wake();
@@ -12,5 +8,3 @@ void screen_timer_stop();
 void set_color_scheme();
 void lv_setup();
 bool is_screen_asleep();
-
-lv_style_t * get_default_label_style();

--- a/CYD-Klipper/src/lib/ESP32OTAPull.h
+++ b/CYD-Klipper/src/lib/ESP32OTAPull.h
@@ -1,0 +1,230 @@
+/*
+ESP32-OTA-Pull - a library for doing "pull" based OTA ("Over The Air") firmware
+updates, where the image updates are posted on the web.
+
+MIT License
+
+Copyright (c) 2022-3 Mikal Hart
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#pragma once
+#include <HTTPClient.h>
+#include <ArduinoJson.h>
+#include <Update.h>
+#include <WiFi.h>
+
+class ESP32OTAPull
+{
+public:
+    enum ActionType { DONT_DO_UPDATE, UPDATE_BUT_NO_BOOT, UPDATE_AND_BOOT };
+
+    // Return codes from CheckForOTAUpdate
+    enum ErrorCode { UPDATE_AVAILABLE = -3, NO_UPDATE_PROFILE_FOUND = -2, NO_UPDATE_AVAILABLE = -1, UPDATE_OK = 0, HTTP_FAILED = 1, WRITE_ERROR = 2, JSON_PROBLEM = 3, OTA_UPDATE_FAIL = 4 };
+
+private:
+    void (*Callback)(int offset, int totallength) = NULL;
+    ActionType Action = UPDATE_AND_BOOT;
+    String Board = ARDUINO_BOARD;
+    String Device = "";
+    String Config = "";
+    String CVersion = "";
+    bool DowngradesAllowed = false;
+
+    int DownloadJson(const char* URL, String& payload)
+    {
+        HTTPClient http;
+        http.begin(URL);
+
+        // Send HTTP GET request
+        int httpResponseCode = http.GET();
+
+        if (httpResponseCode == 200)
+        {
+            payload = http.getString();
+        }
+
+        // Free resources
+        http.end();
+        return httpResponseCode;
+    }
+
+    int DoOTAUpdate(const char* URL, ActionType Action)
+    {
+        HTTPClient http;
+        http.begin(URL);
+
+        // Send HTTP GET request
+        int httpResponseCode = http.GET();
+
+        if (httpResponseCode == 200)
+        {
+            int totalLength = http.getSize();
+
+            // this is required to start firmware update process
+            if (!Update.begin(UPDATE_SIZE_UNKNOWN))
+                return OTA_UPDATE_FAIL;
+
+            // create buffer for read
+            uint8_t buff[1280] = { 0 };
+
+            // get tcp stream
+            WiFiClient* stream = http.getStreamPtr();
+
+            // read all data from server
+            int offset = 0;
+            while (http.connected() && offset < totalLength)
+            {
+                size_t sizeAvail = stream->available();
+                if (sizeAvail > 0)
+                {
+                    size_t bytes_to_read = min(sizeAvail, sizeof(buff));
+                    size_t bytes_read = stream->readBytes(buff, bytes_to_read);
+                    size_t bytes_written = Update.write(buff, bytes_read);
+                    if (bytes_read != bytes_written)
+                    {
+                        // Serial.printf("Unexpected error in OTA: %d %d %d\n", bytes_to_read, bytes_read, bytes_written);
+                        break;
+                    }
+                    offset += bytes_written;
+                    if (Callback != NULL)
+                        Callback(offset, totalLength);
+                }
+            }
+
+            if (offset == totalLength)
+            {
+                Update.end(true);
+                delay(1000);
+
+                // Restart ESP32 to see changes
+                if (Action == UPDATE_BUT_NO_BOOT)
+                    return UPDATE_OK;
+                ESP.restart();
+            }
+            return WRITE_ERROR;
+        }
+
+        http.end();
+        return httpResponseCode;
+    }
+
+public:
+    /// @brief Return the version string of the binary, as reported by the JSON
+    /// @return The firmware version
+    String GetVersion()
+    {
+        return CVersion;
+    }
+
+    /// @brief Override the default "Device" id (MAC Address)
+    /// @param device A string identifying the particular device (instance) (typically e.g., a MAC address)
+    /// @return The current ESP32OTAPull object for chaining
+    ESP32OTAPull &OverrideDevice(const char *device)
+    {
+        Device = device;
+        return *this;
+    }
+
+    /// @brief Override the default "Board" value of ARDUINO_BOARD
+    /// @param board A string identifying the board (class) being targeted
+    /// @return The current ESP32OTAPull object for chaining
+    ESP32OTAPull &OverrideBoard(const char *board)
+    {
+        Board = board;
+        return *this;
+    }
+
+    /// @brief Specify a configuration string that must match any "Config" in JSON
+    /// @param config An arbitrary string showing the current configuration
+    /// @return The current ESP32OTAPull object for chaining
+    ESP32OTAPull &SetConfig(const char *config)
+    {
+        Config = config;
+        return *this;
+    }
+
+    /// @brief Specify whether downgrades (posted version is lower) are allowed
+    /// @param allow_downgrades true if downgrades are allowed
+    /// @return The current ESP32OTAPull object for chaining
+    ESP32OTAPull &AllowDowngrades(bool allow_downgrades)
+    {
+        DowngradesAllowed = allow_downgrades;
+        return *this;
+    }
+
+    /// @brief Specify a callback function to monitor update progress
+    /// @param callback Pointer to a function that is called repeatedly during update
+    /// @return The current ESP32OTAPull object for chaining
+    ESP32OTAPull &SetCallback(void (*callback)(int offset, int totallength))
+    {
+        Callback = callback;
+        return *this;
+    }
+
+    /// @brief The main entry point for OTA Update
+    /// @param JSON_URL The URL for the JSON filter file
+    /// @param CurrentVersion The version # of the current (i.e. to be replaced) sketch
+    /// @param ActionType The action to be performed.  May be any of DONT_DO_UPDATE, UPDATE_BUT_NO_BOOT, UPDATE_AND_BOOT (default)
+    /// @return ErrorCode or HTTP failure code (see enum above)
+    int CheckForOTAUpdate(const char* JSON_URL, const char *CurrentVersion, ActionType Action = UPDATE_AND_BOOT)
+    {
+        CurrentVersion = CurrentVersion == NULL ? "" : CurrentVersion;
+
+        // Downloading OTA Json...
+        String Payload;
+        int httpResponseCode = DownloadJson(JSON_URL, Payload);
+        if (httpResponseCode != 200)
+            return httpResponseCode > 0 ? httpResponseCode : HTTP_FAILED;
+
+        // Deserialize the JSON file downloaded from user's site
+        JsonDocument doc;
+        DeserializationError deserialization = deserializeJson(doc, Payload.c_str());
+        if (deserialization != DeserializationError::Ok)
+            return JSON_PROBLEM;
+
+        String DeviceName = Device.isEmpty() ? WiFi.macAddress() : Device;
+        String BoardName = Board.isEmpty() ? ARDUINO_BOARD : Board;
+        String ConfigName = Config.isEmpty() ? "" : Config;
+        bool foundProfile = false;
+
+        // Step through the configurations looking for a match
+        for (auto config : doc["Configurations"].as<JsonArray>())
+        {
+            String CBoard = config["Board"].isNull() ? "" : (const char *)config["Board"];
+            String CDevice = config["Device"].isNull() ? "" : (const char *)config["Device"];
+            CVersion = config["Version"].isNull() ? "" : (const char *)config["Version"];
+            String CConfig = config["Config"].isNull() ? "" : (const char *)config["Config"];
+            //Serial.printf("Checking %s %s %s %s\n", CBoard.c_str(), CDevice.c_str(), CVersion.c_str(), CConfig.c_str());
+            //Serial.printf("Against %s %s %s %s\n", BoardName.c_str(), DeviceName.c_str(), CurrentVersion, ConfigName.c_str());
+            if ((CBoard.isEmpty() || CBoard == BoardName) &&
+                (CDevice.isEmpty() || CDevice == DeviceName) &&
+                (CConfig.isEmpty() || CConfig == ConfigName))
+            {
+                if (CVersion.isEmpty() || CVersion > String(CurrentVersion) ||
+                    (DowngradesAllowed && CVersion != String(CurrentVersion)))
+                    return Action == DONT_DO_UPDATE ? UPDATE_AVAILABLE : DoOTAUpdate(config["URL"], Action);
+                foundProfile = true;
+            }
+        }
+        return foundProfile ? NO_UPDATE_AVAILABLE : NO_UPDATE_PROFILE_FOUND;
+    }
+};
+

--- a/CYD-Klipper/src/main.cpp
+++ b/CYD-Klipper/src/main.cpp
@@ -8,6 +8,7 @@
 #include "ui/nav_buttons.h"
 #include <Esp.h>
 #include "core/lv_setup.h"
+#include "ui/ota_setup.h"
 
 void setup() {
     Serial.begin(115200);
@@ -18,6 +19,7 @@ void setup() {
     Serial.println("Screen init done");
     
     wifi_init();
+    ota_init();
     ip_init();
     data_setup();
 
@@ -31,4 +33,9 @@ void loop(){
     data_loop();
     lv_timer_handler();
     lv_task_handler();
+
+    if (is_ready_for_ota_update())
+    {
+        ota_do_update();
+    }
 }

--- a/CYD-Klipper/src/ui/ip_setup.cpp
+++ b/CYD-Klipper/src/ui/ip_setup.cpp
@@ -110,7 +110,7 @@ static void power_devices_button(lv_event_t * e) {
     lv_obj_set_size(button, CYD_SCREEN_WIDTH_PX - CYD_SCREEN_GAP_PX * 2, CYD_SCREEN_MIN_BUTTON_HEIGHT_PX);
     lv_obj_add_event_cb(button, destroy_event_user_data, LV_EVENT_CLICKED, panel);
 
-    lv_obj_t * label = lv_label_create_ex(button);
+    lv_obj_t * label = lv_label_create(button);
     lv_label_set_text(label, LV_SYMBOL_CLOSE " Close");
     lv_obj_center(label);
 
@@ -120,7 +120,7 @@ static void power_devices_button(lv_event_t * e) {
 void redraw_connect_screen(){
     lv_obj_clean(lv_scr_act());
 
-    label = lv_label_create_ex(lv_scr_act());
+    label = lv_label_create(lv_scr_act());
     lv_label_set_text(label, "Connecting to Klipper");
     lv_obj_align(label, LV_ALIGN_CENTER, 0, 0);
 
@@ -133,7 +133,7 @@ void redraw_connect_screen(){
     lv_obj_add_event_cb(reset_btn, reset_btn_event_handler, LV_EVENT_CLICKED, NULL);
     lv_obj_set_height(reset_btn, CYD_SCREEN_MIN_BUTTON_HEIGHT_PX);
 
-    lv_obj_t * btn_label = lv_label_create_ex(reset_btn);
+    lv_obj_t * btn_label = lv_label_create(reset_btn);
     lv_label_set_text(btn_label, "Reset");
     lv_obj_center(btn_label);
 
@@ -142,7 +142,7 @@ void redraw_connect_screen(){
         lv_obj_add_event_cb(power_devices_btn, power_devices_button, LV_EVENT_CLICKED, NULL);
         lv_obj_set_height(power_devices_btn, CYD_SCREEN_MIN_BUTTON_HEIGHT_PX);
 
-        btn_label = lv_label_create_ex(power_devices_btn);
+        btn_label = lv_label_create(power_devices_btn);
         lv_label_set_text(btn_label, "Power Devices");
         lv_obj_center(btn_label);
     }
@@ -166,7 +166,7 @@ void ip_init_inner(){
     lv_obj_set_flex_grow(top_root, 1);
     lv_obj_set_style_pad_all(top_root, CYD_SCREEN_GAP_PX, 0);
 
-    label = lv_label_create_ex(top_root);
+    label = lv_label_create(top_root);
     lv_label_set_text(label, "Enter Klipper IP/Hostname and Port");
     lv_obj_set_width(label, CYD_SCREEN_WIDTH_PX - CYD_SCREEN_GAP_PX * 2);
 

--- a/CYD-Klipper/src/ui/main_ui.cpp
+++ b/CYD-Klipper/src/ui/main_ui.cpp
@@ -32,7 +32,7 @@ void error_ui_macros_open(lv_event_t * e){
     lv_obj_set_size(button, CYD_SCREEN_WIDTH_PX - CYD_SCREEN_GAP_PX * 2, CYD_SCREEN_MIN_BUTTON_HEIGHT_PX);
     lv_obj_add_event_cb(button, destroy_event_user_data, LV_EVENT_CLICKED, panel);
 
-    lv_obj_t * label = lv_label_create_ex(button);
+    lv_obj_t * label = lv_label_create(button);
     lv_label_set_text(label, LV_SYMBOL_CLOSE " Close");
     lv_obj_center(label);
 
@@ -49,10 +49,10 @@ void error_ui(){
     lv_obj_set_flex_align(panel, LV_FLEX_ALIGN_SPACE_BETWEEN, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
     
     lv_obj_t * label;
-    label = lv_label_create_ex(panel);
+    label = lv_label_create(panel);
     lv_label_set_text(label, LV_SYMBOL_WARNING " Printer is not ready");
 
-    label = lv_label_create_ex(panel);
+    label = lv_label_create(panel);
     lv_label_set_text(label, printer.state_message);
     lv_obj_set_width(label, CYD_SCREEN_WIDTH_PX - CYD_SCREEN_GAP_PX * 2);
     lv_obj_clear_flag(label, LV_OBJ_FLAG_SCROLLABLE);
@@ -67,7 +67,7 @@ void error_ui(){
     lv_obj_add_event_cb(btn, btn_click_restart, LV_EVENT_CLICKED, NULL);
     lv_obj_set_flex_grow(btn, 1);
 
-    label = lv_label_create_ex(btn);
+    label = lv_label_create(btn);
     lv_label_set_text(label, "Restart");
     lv_obj_center(label);
 
@@ -76,7 +76,7 @@ void error_ui(){
     lv_obj_add_event_cb(btn, btn_click_firmware_restart, LV_EVENT_CLICKED, NULL);
     lv_obj_set_flex_grow(btn, 1);
 
-    label = lv_label_create_ex(btn);
+    label = lv_label_create(btn);
     lv_label_set_text(label, "FW Restart");
     lv_obj_center(label);
 
@@ -86,7 +86,7 @@ void error_ui(){
         lv_obj_add_event_cb(btn, error_ui_macros_open, LV_EVENT_CLICKED, NULL);
         lv_obj_set_flex_grow(btn, 1);
 
-        label = lv_label_create_ex(btn);
+        label = lv_label_create(btn);
         lv_label_set_text(label, "Devices");
         lv_obj_center(label);
     }

--- a/CYD-Klipper/src/ui/nav_buttons.cpp
+++ b/CYD-Klipper/src/ui/nav_buttons.cpp
@@ -84,7 +84,7 @@ void create_button(const char* icon, const char* name, lv_event_cb_t button_clic
     if (button_click != NULL)
         lv_obj_add_event_cb(btn, button_click, LV_EVENT_CLICKED, NULL);
 
-    lv_obj_t* label = lv_label_create_ex(btn);
+    lv_obj_t* label = lv_label_create(btn);
     lv_label_set_text(label, icon);
     lv_obj_align(label, LV_ALIGN_CENTER, 0, -1 * CYD_SCREEN_GAP_PX);
     

--- a/CYD-Klipper/src/ui/ota_setup.cpp
+++ b/CYD-Klipper/src/ui/ota_setup.cpp
@@ -54,13 +54,13 @@ void ota_do_update(bool variant_automatic)
     lv_obj_align(panel, LV_ALIGN_TOP_LEFT, 0, 0);
     lv_layout_flex_column(panel, LV_FLEX_ALIGN_CENTER);
 
-    lv_obj_t *label = lv_label_create_ex(panel);
+    lv_obj_t *label = lv_label_create(panel);
     lv_label_set_text(label, "Updating OTA...");
 
     percentage_bar = lv_bar_create(panel);
     lv_obj_set_size(percentage_bar, CYD_SCREEN_WIDTH_PX - CYD_SCREEN_GAP_PX * 3, CYD_SCREEN_MIN_BUTTON_HEIGHT_PX * 0.75f);
 
-    update_label = lv_label_create_ex(panel);
+    update_label = lv_label_create(panel);
     lv_label_set_text(update_label, "0/0");
 
     if (!variant_automatic) {

--- a/CYD-Klipper/src/ui/ota_setup.cpp
+++ b/CYD-Klipper/src/ui/ota_setup.cpp
@@ -1,0 +1,103 @@
+#include "../lib/ESP32OTAPull.h"
+#include "lvgl.h"
+#include "ui_utils.h"
+#include "../core/lv_setup.h"
+#include "../core/data_setup.h"
+#include "../conf/global_config.h"
+#include "ota_setup.h"
+
+//const char *ota_url = "https://gist.githubusercontent.com/suchmememanyskill/ece418fe199e155340de6c224a0badf2/raw/0d6762d68bc807cbecc71e40d55b76692397a7b3/update.json"; // Test url
+const char *ota_url = "https://suchmememanyskill.github.io/CYD-Klipper/OTA.json"; // Prod url
+ESP32OTAPull ota_pull;
+static bool update_available;
+static bool ready_for_ota_update = false;
+
+String ota_new_version_name()
+{
+    return ota_pull.GetVersion();
+}
+
+bool ota_has_update()
+{
+    return update_available;
+}
+
+static int last_callback_time = 0;
+lv_obj_t *percentage_bar;
+lv_obj_t *update_label;
+void do_update_callback(int offset, int totallength)
+{
+    int now = millis();
+    if (now - last_callback_time < 1000)
+    {
+        return;
+    }
+
+    last_callback_time = now;
+
+    float percentage = (float)offset / (float)totallength; // 0 -> 1
+    lv_bar_set_value(percentage_bar, percentage * 100, LV_ANIM_OFF);
+    lv_label_set_text_fmt(update_label, "%d/%d bytes", offset, totallength);
+
+    lv_refr_now(NULL);
+    lv_timer_handler();
+    lv_task_handler();
+}
+
+void ota_do_update(bool variant_automatic)
+{
+    Serial.println("Starting OTA Update");
+    lv_obj_clean(lv_scr_act());
+
+    lv_obj_t *panel = lv_create_empty_panel(lv_scr_act());
+    lv_obj_set_size(panel, CYD_SCREEN_WIDTH_PX, CYD_SCREEN_HEIGHT_PX);
+    lv_obj_align(panel, LV_ALIGN_TOP_LEFT, 0, 0);
+    lv_layout_flex_column(panel, LV_FLEX_ALIGN_CENTER);
+
+    lv_obj_t *label = lv_label_create_ex(panel);
+    lv_label_set_text(label, "Updating OTA...");
+
+    percentage_bar = lv_bar_create(panel);
+    lv_obj_set_size(percentage_bar, CYD_SCREEN_WIDTH_PX - CYD_SCREEN_GAP_PX * 3, CYD_SCREEN_MIN_BUTTON_HEIGHT_PX * 0.75f);
+
+    update_label = lv_label_create_ex(panel);
+    lv_label_set_text(update_label, "0/0");
+
+    if (!variant_automatic) {
+        Serial.println("Freezing Background Tasks");
+        screen_timer_wake();
+        screen_timer_stop();
+        freeze_request_thread();
+    }
+
+    lv_refr_now(NULL);
+    lv_timer_handler();
+    lv_task_handler();
+
+    ota_pull.SetCallback(do_update_callback);
+    ota_pull.CheckForOTAUpdate(ota_url, REPO_VERSION, ESP32OTAPull::ActionType::UPDATE_AND_BOOT);
+}
+
+void ota_init()
+{
+    //ota_pull.AllowDowngrades(true);
+    int result = ota_pull.CheckForOTAUpdate(ota_url, REPO_VERSION, ESP32OTAPull::ActionType::DONT_DO_UPDATE);
+    Serial.printf("OTA Update Result: %d\n", result);
+    update_available = result == ESP32OTAPull::UPDATE_AVAILABLE;
+
+    if (global_config.autoOtaUpdate && update_available)
+    {
+        ota_do_update(true);
+    }
+}
+
+void set_ready_for_ota_update()
+{
+    ready_for_ota_update = true;
+}
+
+bool is_ready_for_ota_update()
+{
+    return ready_for_ota_update;
+}
+

--- a/CYD-Klipper/src/ui/ota_setup.h
+++ b/CYD-Klipper/src/ui/ota_setup.h
@@ -1,0 +1,8 @@
+#pragma once
+
+String ota_new_version_name();
+bool ota_has_update();
+void ota_do_update(bool variant_automatic = false);
+void ota_init();
+void set_ready_for_ota_update();
+bool is_ready_for_ota_update();

--- a/CYD-Klipper/src/ui/panels/macros_panel.cpp
+++ b/CYD-Klipper/src/ui/panels/macros_panel.cpp
@@ -28,7 +28,7 @@ void macros_panel_add_macros_to_panel(lv_obj_t * root_panel, MACROSQUERY query){
         lv_layout_flex_row(panel, LV_FLEX_ALIGN_END);
         lv_obj_set_size(panel, CYD_SCREEN_PANEL_WIDTH_PX - CYD_SCREEN_GAP_PX * 3, CYD_SCREEN_MIN_BUTTON_HEIGHT_PX);
 
-        lv_obj_t * label = lv_label_create_ex(panel);
+        lv_obj_t * label = lv_label_create(panel);
         lv_label_set_text(label, macro);
         lv_label_set_long_mode(label, LV_LABEL_LONG_SCROLL_CIRCULAR);
         lv_obj_set_flex_grow(label, 1);
@@ -37,7 +37,7 @@ void macros_panel_add_macros_to_panel(lv_obj_t * root_panel, MACROSQUERY query){
         lv_obj_add_event_cb(btn, btn_press, LV_EVENT_CLICKED, (void*)macro);
         lv_obj_set_height(btn, CYD_SCREEN_MIN_BUTTON_HEIGHT_PX);
 
-        label = lv_label_create_ex(btn);
+        label = lv_label_create(btn);
         lv_label_set_text(label, "Run");
         lv_obj_center(label);
 
@@ -66,7 +66,7 @@ void macros_panel_add_power_devices_to_panel(lv_obj_t * root_panel, POWERQUERY q
         lv_layout_flex_row(panel, LV_FLEX_ALIGN_END);
         lv_obj_set_size(panel, CYD_SCREEN_PANEL_WIDTH_PX - CYD_SCREEN_GAP_PX * 3, CYD_SCREEN_MIN_BUTTON_HEIGHT_PX);
 
-        lv_obj_t * label = lv_label_create_ex(panel);
+        lv_obj_t * label = lv_label_create(panel);
         lv_label_set_text(label, power_device_name);
         lv_label_set_long_mode(label, LV_LABEL_LONG_SCROLL_CIRCULAR);
         lv_obj_set_flex_grow(label, 1);
@@ -90,14 +90,14 @@ void macros_panel_init(lv_obj_t* panel) {
     lv_obj_set_size(btn, CYD_SCREEN_PANEL_WIDTH_PX - CYD_SCREEN_GAP_PX * 2, CYD_SCREEN_MIN_BUTTON_HEIGHT_PX);
     lv_obj_align(btn, LV_ALIGN_TOP_MID, 0, CYD_SCREEN_GAP_PX);
 
-    lv_obj_t * label = lv_label_create_ex(btn);
+    lv_obj_t * label = lv_label_create(btn);
     lv_label_set_text(label, LV_SYMBOL_SETTINGS " Screen Settings");
     lv_obj_center(label);
 
     MACROSQUERY query = macros_query();
     POWERQUERY power = power_devices_query();
     if (query.count == 0 && power.count == 0){
-        label = lv_label_create_ex(panel);
+        label = lv_label_create(panel);
         lv_label_set_text(label, "No macros found.\nMacros with the description\n\"CYD_SCREEN_MACRO\"\nwill show up here.");
         lv_obj_align(label, LV_ALIGN_CENTER, 0, 0);
         return;

--- a/CYD-Klipper/src/ui/panels/move_panel.cpp
+++ b/CYD-Klipper/src/ui/panels/move_panel.cpp
@@ -120,7 +120,7 @@ inline void root_panel_steppers_locked(lv_obj_t * root_panel){
     lv_obj_add_event_cb(btn, home_button_click, LV_EVENT_CLICKED, NULL);
     lv_obj_set_flex_grow(btn, 1);
 
-    lv_obj_t * label = lv_label_create_ex(btn);
+    lv_obj_t * label = lv_label_create(btn);
     lv_label_set_text(label, LV_SYMBOL_HOME "Home Axis");
     lv_obj_center(label);
 
@@ -129,12 +129,12 @@ inline void root_panel_steppers_locked(lv_obj_t * root_panel){
     lv_obj_add_event_cb(btn, disable_steppers_click, LV_EVENT_CLICKED, NULL);
     lv_obj_set_flex_grow(btn, 1);
 
-    label = lv_label_create_ex(btn);
+    label = lv_label_create(btn);
     lv_label_set_text(label, LV_SYMBOL_EYE_CLOSE " Disable Step");
     lv_obj_center(label);
 
     for (int row = 0; row < 3; row++) {
-        label = lv_label_create_ex(panel);
+        label = lv_label_create(panel);
         lv_label_set_text(label, "???");
         lv_obj_set_width(label, width);
         lv_obj_add_event_cb(label, position_callbacks[row], LV_EVENT_MSG_RECEIVED, NULL);
@@ -151,7 +151,7 @@ inline void root_panel_steppers_locked(lv_obj_t * root_panel){
             lv_obj_add_event_cb(btn, button_callbacks[row], LV_EVENT_CLICKED, (void*)(offsets[row] + col));
             lv_obj_set_flex_grow(btn, 1);
 
-            label = lv_label_create_ex(btn);
+            label = lv_label_create(btn);
             lv_label_set_text(label, offset_labels[row][col]);
             lv_obj_center(label);
         }
@@ -165,14 +165,14 @@ inline void root_panel_steppers_unlocked(lv_obj_t * root_panel){
     lv_obj_set_style_pad_all(panel, CYD_SCREEN_GAP_PX, 0);
     lv_layout_flex_column(panel, LV_FLEX_ALIGN_CENTER);
 
-    lv_obj_t * label = lv_label_create_ex(panel);
+    lv_obj_t * label = lv_label_create(panel);
     lv_label_set_text(label, LV_SYMBOL_EYE_CLOSE " Steppers unlocked");
 
     lv_obj_t * btn = lv_btn_create(panel);
     lv_obj_set_height(btn, CYD_SCREEN_MIN_BUTTON_HEIGHT_PX);
     lv_obj_add_event_cb(btn, home_button_click, LV_EVENT_CLICKED, NULL);
 
-    label = lv_label_create_ex(btn);
+    label = lv_label_create(btn);
     lv_label_set_text(label, LV_SYMBOL_HOME "Home Axis");
     lv_obj_center(label);
 }

--- a/CYD-Klipper/src/ui/panels/print_panel.cpp
+++ b/CYD-Klipper/src/ui/panels/print_panel.cpp
@@ -52,11 +52,11 @@ static void btn_print_file_verify(lv_event_t * e){
     lv_obj_set_size(panel, CYD_SCREEN_WIDTH_PX - CYD_SCREEN_GAP_PX * 4, CYD_SCREEN_HEIGHT_PX - CYD_SCREEN_GAP_PX * 3);
     lv_obj_align(panel, LV_ALIGN_CENTER, 0, 0);
 
-    lv_obj_t * label = lv_label_create_ex(panel);
+    lv_obj_t * label = lv_label_create(panel);
     lv_label_set_text(label, "Print File");
     lv_obj_align(label, LV_ALIGN_TOP_LEFT, 0, 0);
 
-    label = lv_label_create_ex(panel);
+    label = lv_label_create(panel);
     lv_label_set_text(label, selected_file->name);
     lv_obj_align(label, LV_ALIGN_CENTER, 0, -20);
     lv_obj_set_width(label, CYD_SCREEN_WIDTH_PX - CYD_SCREEN_GAP_PX * 10);
@@ -67,7 +67,7 @@ static void btn_print_file_verify(lv_event_t * e){
     lv_obj_set_size(btn, CYD_SCREEN_MIN_BUTTON_WIDTH_PX * button_size_mult, CYD_SCREEN_MIN_BUTTON_HEIGHT_PX * button_size_mult);
     lv_obj_add_event_cb(btn, destroy_event_user_data, LV_EVENT_CLICKED, panel);
 
-    label = lv_label_create_ex(btn);
+    label = lv_label_create(btn);
     lv_label_set_text(label, LV_SYMBOL_CLOSE);
     lv_obj_center(label);
 
@@ -76,7 +76,7 @@ static void btn_print_file_verify(lv_event_t * e){
     lv_obj_set_size(btn, CYD_SCREEN_MIN_BUTTON_WIDTH_PX * button_size_mult, CYD_SCREEN_MIN_BUTTON_HEIGHT_PX * button_size_mult);
     lv_obj_add_event_cb(btn, btn_print_file, LV_EVENT_CLICKED, panel);
     
-    label = lv_label_create_ex(btn);
+    label = lv_label_create(btn);
     lv_label_set_text(label, LV_SYMBOL_OK);
     lv_obj_center(label);
 }
@@ -98,7 +98,6 @@ void print_panel_init(lv_obj_t* panel){
     int count = 0;
     while (files != NULL && files->name != NULL && count <= 20){
         lv_obj_t * btn = lv_list_add_btn(list, LV_SYMBOL_FILE, files->name);
-        lv_obj_add_style(btn, get_default_label_style(), 0);
         lv_obj_set_style_bg_opa(btn, LV_OPA_TRANSP, 0); 
         lv_obj_add_event_cb(btn, btn_print_file_verify, LV_EVENT_CLICKED, (void*)files);
 
@@ -108,7 +107,7 @@ void print_panel_init(lv_obj_t* panel){
 
     if (count <= 0){
         lv_obj_del(list);
-        lv_obj_t * label = lv_label_create_ex(panel);
+        lv_obj_t * label = lv_label_create(panel);
         lv_label_set_text(label, "Failed to read files.");
         lv_obj_align(label, LV_ALIGN_CENTER, 0, 0);
     }

--- a/CYD-Klipper/src/ui/panels/progress_panel.cpp
+++ b/CYD-Klipper/src/ui/panels/progress_panel.cpp
@@ -57,7 +57,7 @@ void progress_panel_init(lv_obj_t* panel){
     lv_layout_flex_column(center_panel);
 
     // Filename
-    lv_obj_t * label = lv_label_create_ex(center_panel);
+    lv_obj_t * label = lv_label_create(center_panel);
     lv_label_set_text(label, printer.print_filename);
     lv_label_set_long_mode(label, LV_LABEL_LONG_SCROLL_CIRCULAR);
     lv_obj_set_width(label, panel_width);
@@ -73,21 +73,21 @@ void progress_panel_init(lv_obj_t* panel){
     lv_obj_set_size(time_est_panel, panel_width, LV_SIZE_CONTENT);
 
     // Elapsed Time
-    label = lv_label_create_ex(time_est_panel);
+    label = lv_label_create(time_est_panel);
     lv_label_set_text(label, "???");
     lv_obj_align(label, LV_ALIGN_LEFT_MID, 0, 0);
     lv_obj_add_event_cb(label, update_printer_data_elapsed_time, LV_EVENT_MSG_RECEIVED, NULL);
     lv_msg_subsribe_obj(DATA_PRINTER_DATA, label, NULL);
 
     // Remaining Time
-    label = lv_label_create_ex(time_est_panel);
+    label = lv_label_create(time_est_panel);
     lv_label_set_text(label, "???");
     lv_obj_align(label, LV_ALIGN_RIGHT_MID, 0, 0);
     lv_obj_add_event_cb(label, update_printer_data_remaining_time, LV_EVENT_MSG_RECEIVED, NULL);
     lv_msg_subsribe_obj(DATA_PRINTER_DATA, label, NULL);
 
     // Percentage
-    label = lv_label_create_ex(time_est_panel);
+    label = lv_label_create(time_est_panel);
     lv_label_set_text(label, "???");
     lv_obj_align(label, LV_ALIGN_CENTER, 0, 0);
     lv_obj_add_event_cb(label, update_printer_data_percentage, LV_EVENT_MSG_RECEIVED, NULL);
@@ -99,7 +99,7 @@ void progress_panel_init(lv_obj_t* panel){
     lv_obj_set_size(btn, CYD_SCREEN_MIN_BUTTON_WIDTH_PX * button_size_mult, CYD_SCREEN_MIN_BUTTON_HEIGHT_PX * button_size_mult);
     lv_obj_add_event_cb(btn, btn_click_stop, LV_EVENT_CLICKED, NULL);
 
-    label = lv_label_create_ex(btn);
+    label = lv_label_create(btn);
     lv_label_set_text(label, LV_SYMBOL_STOP);
     lv_obj_center(label);
 
@@ -108,7 +108,7 @@ void progress_panel_init(lv_obj_t* panel){
         btn = lv_btn_create(panel);
         lv_obj_add_event_cb(btn, btn_click_resume, LV_EVENT_CLICKED, NULL);
 
-        label = lv_label_create_ex(btn);
+        label = lv_label_create(btn);
         lv_label_set_text(label, LV_SYMBOL_PLAY);
         lv_obj_center(label);
     }
@@ -117,7 +117,7 @@ void progress_panel_init(lv_obj_t* panel){
         btn = lv_btn_create(panel);
         lv_obj_add_event_cb(btn, btn_click_pause, LV_EVENT_CLICKED, NULL);
 
-        label = lv_label_create_ex(btn);
+        label = lv_label_create(btn);
         lv_label_set_text(label, LV_SYMBOL_PAUSE);
         lv_obj_center(label);
     }

--- a/CYD-Klipper/src/ui/panels/settings_panel.cpp
+++ b/CYD-Klipper/src/ui/panels/settings_panel.cpp
@@ -105,7 +105,7 @@ void create_settings_widget(const char* label_text, lv_obj_t* object, lv_obj_t* 
     lv_obj_t * panel = lv_create_empty_panel(root_panel);
     lv_obj_set_size(panel, CYD_SCREEN_PANEL_WIDTH_PX - CYD_SCREEN_GAP_PX * 3, CYD_SCREEN_MIN_BUTTON_HEIGHT_PX);
 
-    lv_obj_t * label = lv_label_create_ex(panel);
+    lv_obj_t * label = lv_label_create(panel);
     lv_label_set_text(label, label_text);
     lv_obj_align(label, LV_ALIGN_LEFT_MID, 0, 0);
 
@@ -128,7 +128,7 @@ void settings_panel_init(lv_obj_t* panel){
     lv_obj_t * btn = lv_btn_create(panel);
     lv_obj_add_event_cb(btn, reset_wifi_click, LV_EVENT_CLICKED, NULL);
 
-    lv_obj_t * label = lv_label_create_ex(btn);
+    lv_obj_t * label = lv_label_create(btn);
     lv_label_set_text(label, "Restart");
     lv_obj_center(label);
 
@@ -138,7 +138,7 @@ void settings_panel_init(lv_obj_t* panel){
     btn = lv_btn_create(panel);
     lv_obj_add_event_cb(btn, reset_calibration_click, LV_EVENT_CLICKED, NULL);
 
-    label = lv_label_create_ex(btn);
+    label = lv_label_create(btn);
     lv_label_set_text(label, "Restart");
     lv_obj_center(label);
 
@@ -167,14 +167,12 @@ void settings_panel_init(lv_obj_t* panel){
     lv_obj_t * dropdown = lv_dropdown_create(panel);
     lv_dropdown_set_options(dropdown, "Blue\nGreen\nGrey\nYellow\nOrange\nRed\nPurple");
     lv_dropdown_set_selected(dropdown, global_config.color_scheme);
-    lv_obj_add_style(dropdown, get_default_label_style(), 0);
     lv_obj_add_event_cb(dropdown, theme_dropdown, LV_EVENT_VALUE_CHANGED, NULL);
 
     create_settings_widget("Theme", dropdown, panel);
 
     dropdown = lv_dropdown_create(panel);
     lv_dropdown_set_options(dropdown, brightness_options);
-    lv_obj_add_style(dropdown, get_default_label_style(), 0);
     lv_obj_add_event_cb(dropdown, brightness_dropdown, LV_EVENT_VALUE_CHANGED, NULL);
 
     for (int i = 0; i < SIZEOF(brightness_options_values); i++){
@@ -189,7 +187,6 @@ void settings_panel_init(lv_obj_t* panel){
 #ifndef CYD_SCREEN_DISABLE_TIMEOUT
     dropdown = lv_dropdown_create(panel);
     lv_dropdown_set_options(dropdown, wake_timeout_options);
-    lv_obj_add_style(dropdown, get_default_label_style(), 0);
     lv_obj_add_event_cb(dropdown, wake_timeout_dropdown, LV_EVENT_VALUE_CHANGED, NULL);
 
     for (int i = 0; i < SIZEOF(wake_timeout_options_values); i++){
@@ -222,7 +219,7 @@ void settings_panel_init(lv_obj_t* panel){
     create_settings_widget("Screen On During Print", toggle, panel);
 #endif
 
-    label = lv_label_create_ex(panel);
+    label = lv_label_create(panel);
     lv_label_set_text(label, REPO_VERSION "  ");
 
     create_settings_widget("Version", label, panel, false);
@@ -231,14 +228,14 @@ void settings_panel_init(lv_obj_t* panel){
         btn = lv_btn_create(panel);
         lv_obj_add_event_cb(btn, btn_ota_do_update, LV_EVENT_CLICKED, NULL);
 
-        label = lv_label_create_ex(btn);
+        label = lv_label_create(btn);
         lv_label_set_text_fmt(label, "Update to %s", ota_new_version_name().c_str());
         lv_obj_center(label);
 
         create_settings_widget("Device", btn, panel);
     }
     else {
-        label = lv_label_create_ex(panel);
+        label = lv_label_create(panel);
         lv_label_set_text(label, ARDUINO_BOARD "  ");
 
         create_settings_widget("Device", label, panel, false);

--- a/CYD-Klipper/src/ui/panels/stats_panel.cpp
+++ b/CYD-Klipper/src/ui/panels/stats_panel.cpp
@@ -145,7 +145,7 @@ void create_state_button(lv_obj_t * root, lv_event_cb_t label, lv_event_cb_t but
     lv_obj_set_size(btn, CYD_SCREEN_PANEL_WIDTH_PX / 2 - CYD_SCREEN_GAP_PX * 3, CYD_SCREEN_MIN_BUTTON_HEIGHT_PX);
     lv_obj_add_event_cb(btn, button, LV_EVENT_CLICKED, NULL);
 
-    lv_obj_t * label_obj = lv_label_create_ex(btn);
+    lv_obj_t * label_obj = lv_label_create(btn);
     lv_obj_add_event_cb(label_obj, label, LV_EVENT_MSG_RECEIVED, NULL);
     lv_msg_subscribe_obj(DATA_PRINTER_DATA, label_obj, NULL);
     lv_obj_align(label_obj, LV_ALIGN_CENTER, 0, 0);
@@ -192,11 +192,11 @@ void create_stat_text_block(lv_obj_t * root, const char* label, lv_event_cb_t va
     lv_layout_flex_column(panel , LV_FLEX_ALIGN_START, CYD_SCREEN_GAP_PX / 2, CYD_SCREEN_GAP_PX / 2);
     lv_obj_set_flex_align(panel, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
 
-    lv_obj_t * label_obj = lv_label_create_ex(panel);
+    lv_obj_t * label_obj = lv_label_create(panel);
     lv_label_set_text(label_obj, label);
     lv_obj_set_style_text_font(label_obj, &CYD_SCREEN_FONT_SMALL, 0);
 
-    lv_obj_t * value_obj = lv_label_create_ex(panel);
+    lv_obj_t * value_obj = lv_label_create(panel);
     lv_obj_add_event_cb(value_obj, value, LV_EVENT_MSG_RECEIVED, NULL);
     lv_msg_subscribe_obj(DATA_PRINTER_DATA, value_obj, NULL);
 }

--- a/CYD-Klipper/src/ui/panels/temp_panel.cpp
+++ b/CYD-Klipper/src/ui/panels/temp_panel.cpp
@@ -226,7 +226,7 @@ void temp_panel_init(lv_obj_t * panel){
         lv_layout_flex_column(temp_rows[tempIter]);
         lv_obj_set_size(temp_rows[tempIter], element_width, LV_SIZE_CONTENT);
 
-        lv_obj_t * label = lv_label_create_ex(temp_rows[tempIter]);
+        lv_obj_t * label = lv_label_create(temp_rows[tempIter]);
         lv_label_set_text(label, "???");
         lv_obj_add_event_cb(label, (tempIter == 0) ? update_printer_data_hotend_temp : update_printer_data_bed_temp, LV_EVENT_MSG_RECEIVED, NULL);
         lv_msg_subscribe_obj(DATA_PRINTER_DATA, label, NULL);
@@ -242,7 +242,7 @@ void temp_panel_init(lv_obj_t * panel){
             lv_obj_set_flex_grow(btn, 1);
             lv_obj_set_height(btn, CYD_SCREEN_MIN_BUTTON_HEIGHT_PX);
 
-            label = lv_label_create_ex(btn);
+            label = lv_label_create(btn);
             lv_label_set_text(label, "???");
             lv_obj_center(label);
             lv_obj_add_event_cb(label, update_temp_preset_label, LV_EVENT_MSG_RECEIVED, reinterpret_cast<void*>(TARGET_HOTEND_CONFIG_1 + buttonIter + tempIter * 3));
@@ -254,7 +254,7 @@ void temp_panel_init(lv_obj_t * panel){
         lv_obj_set_flex_grow(btn, 1);
         lv_obj_set_height(btn, CYD_SCREEN_MIN_BUTTON_HEIGHT_PX);
 
-        label = lv_label_create_ex(btn);
+        label = lv_label_create(btn);
         lv_label_set_text(label, "Set");
         lv_obj_center(label);
     }
@@ -274,7 +274,7 @@ void temp_panel_init(lv_obj_t * panel){
     lv_obj_add_event_cb(btn, btn_extrude, LV_EVENT_CLICKED, NULL);
     lv_obj_set_height(btn, CYD_SCREEN_MIN_BUTTON_HEIGHT_PX);
 
-    lv_obj_t * label = lv_label_create_ex(btn);
+    lv_obj_t * label = lv_label_create(btn);
     lv_label_set_text(label, LV_SYMBOL_DOWN " Extrude");
     lv_obj_center(label);
 
@@ -283,7 +283,7 @@ void temp_panel_init(lv_obj_t * panel){
     lv_obj_add_event_cb(btn, btn_retract, LV_EVENT_CLICKED, NULL);
     lv_obj_set_height(btn, CYD_SCREEN_MIN_BUTTON_HEIGHT_PX);
 
-    label = lv_label_create_ex(btn);
+    label = lv_label_create(btn);
     lv_label_set_text(label, LV_SYMBOL_UP " Retract");
     lv_obj_center(label);
 
@@ -292,7 +292,7 @@ void temp_panel_init(lv_obj_t * panel){
     lv_obj_add_event_cb(btn, cooldown_temp, LV_EVENT_CLICKED, NULL);
     lv_obj_set_height(btn, CYD_SCREEN_MIN_BUTTON_HEIGHT_PX);
 
-    label = lv_label_create_ex(btn);
+    label = lv_label_create(btn);
     lv_label_set_text(label, "Cooldown");
     lv_obj_center(label);
 
@@ -302,7 +302,7 @@ void temp_panel_init(lv_obj_t * panel){
     lv_obj_set_height(btn, CYD_SCREEN_MIN_BUTTON_HEIGHT_PX);
     lv_obj_add_flag(btn, LV_OBJ_FLAG_CHECKABLE);
 
-    label = lv_label_create_ex(btn);
+    label = lv_label_create(btn);
     lv_label_set_text(label, "Edit Presets");
     lv_obj_center(label);
 

--- a/CYD-Klipper/src/ui/panels/temp_panel.cpp
+++ b/CYD-Klipper/src/ui/panels/temp_panel.cpp
@@ -119,21 +119,26 @@ static void keyboard_callback(lv_event_t * e){
 
     if(code == LV_EVENT_DEFOCUSED || code == LV_EVENT_CANCEL || code == LV_EVENT_READY) {
         lv_keyboard_set_textarea(kb, NULL);
-        lv_obj_del(kb);
-        lv_obj_del(ta);
+        lv_obj_del(lv_obj_get_parent(kb));
     }
 }
 
 static void show_keyboard(lv_event_t * e){
-    lv_obj_t * keyboard = lv_keyboard_create(root_panel);
-    lv_obj_t * ta = lv_textarea_create(root_panel);
-    // TODO: Hack, should be fixed before finishing porting
-    lv_obj_set_size(ta, CYD_SCREEN_PANEL_WIDTH_PX, 120);
-    lv_obj_align(ta, LV_ALIGN_TOP_MID, 0, 0);
+    lv_obj_t * parent = lv_create_empty_panel(root_panel);
+    lv_obj_set_style_bg_opa(parent, LV_OPA_50, 0); 
+    lv_obj_set_size(parent, CYD_SCREEN_PANEL_WIDTH_PX, CYD_SCREEN_HEIGHT_PX);
+    lv_layout_flex_column(parent, LV_FLEX_ALIGN_SPACE_BETWEEN);
+
+    lv_obj_t * empty_panel = lv_create_empty_panel(parent);
+    lv_obj_set_flex_grow(empty_panel, 1);
+
+    lv_obj_t * ta = lv_textarea_create(parent);
+    lv_obj_t * keyboard = lv_keyboard_create(parent);
+
+    lv_obj_set_width(ta, CYD_SCREEN_PANEL_WIDTH_PX / 2);
     lv_textarea_set_max_length(ta, 3);
-    //lv_textarea_set_one_line(ta, true);
+    lv_textarea_set_one_line(ta, true);
     lv_textarea_set_text(ta, "");
-    lv_textarea_set_align(ta, LV_TEXT_ALIGN_CENTER);
     lv_obj_add_event_cb(ta, keyboard_callback, LV_EVENT_ALL, keyboard);
 
     lv_keyboard_set_mode(keyboard, LV_KEYBOARD_MODE_NUMBER);

--- a/CYD-Klipper/src/ui/ui_utils.cpp
+++ b/CYD-Klipper/src/ui/ui_utils.cpp
@@ -3,13 +3,6 @@
 #include "../core/data_setup.h"
 #include "../core/lv_setup.h"
 
-lv_obj_t* lv_label_create_ex(lv_obj_t* parent)
-{
-    lv_obj_t* label = lv_label_create(parent);
-    lv_obj_add_style(label, get_default_label_style(), 0);
-    return label;
-}
-
 lv_obj_t* lv_create_empty_panel(lv_obj_t* root) {
     lv_obj_t* panel = lv_obj_create(root); 
     lv_obj_set_style_border_width(panel, 0, 0); 
@@ -61,11 +54,11 @@ void lv_create_fullscreen_button_matrix_popup(lv_obj_t * root, lv_event_cb_t tit
     lv_obj_align(btn, LV_ALIGN_RIGHT_MID, 0, 0);
     lv_obj_add_event_cb(btn, destroy_event_user_data, LV_EVENT_CLICKED, panel);
 
-    lv_obj_t * label = lv_label_create_ex(btn);
+    lv_obj_t * label = lv_label_create(btn);
     lv_label_set_text(label, LV_SYMBOL_CLOSE);
     lv_obj_center(label);
 
-    label = lv_label_create_ex(top_menu_row);
+    label = lv_label_create(top_menu_row);
     lv_label_set_text(label, "-");
     lv_obj_align(label, LV_ALIGN_LEFT_MID, 0, 0);
     lv_obj_add_event_cb(label, title, LV_EVENT_MSG_RECEIVED, NULL);
@@ -87,7 +80,7 @@ void lv_create_fullscreen_button_matrix_popup(lv_obj_t * root, lv_event_cb_t tit
             lv_obj_set_size(btn, column_width, CYD_SCREEN_MIN_BUTTON_HEIGHT_PX);
             lv_obj_add_event_cb(btn, columns[i].event, LV_EVENT_CLICKED, (void*)columns[i].data[j]);
 
-            label = lv_label_create_ex(btn);
+            label = lv_label_create(btn);
             lv_label_set_text(label, columns[i].labels[j]);
             lv_obj_center(label);
         }

--- a/CYD-Klipper/src/ui/ui_utils.h
+++ b/CYD-Klipper/src/ui/ui_utils.h
@@ -18,7 +18,6 @@ typedef struct {
     int length;
 } lv_button_column_t;
 
-lv_obj_t* lv_label_create_ex(lv_obj_t* parent);
 lv_obj_t* lv_create_empty_panel(lv_obj_t* root);
 void lv_layout_flex_column(lv_obj_t* obj, lv_flex_align_t allign = LV_FLEX_ALIGN_START, lv_coord_t pad_column = CYD_SCREEN_GAP_PX, lv_coord_t pad_row = CYD_SCREEN_GAP_PX);
 void lv_layout_flex_row(lv_obj_t* obj, lv_flex_align_t allign = LV_FLEX_ALIGN_START, lv_coord_t pad_column = CYD_SCREEN_GAP_PX, lv_coord_t pad_row = CYD_SCREEN_GAP_PX);

--- a/CYD-Klipper/src/ui/wifi_setup.cpp
+++ b/CYD-Klipper/src/ui/wifi_setup.cpp
@@ -58,7 +58,7 @@ void wifi_pass_entry(const char* ssid){
     lv_obj_set_flex_grow(top_root, 1);
     lv_obj_set_style_pad_all(top_root, CYD_SCREEN_GAP_PX, 0);
 
-    lv_obj_t * label = lv_label_create_ex(top_root);
+    lv_obj_t * label = lv_label_create(top_root);
     lv_label_set_text(label, "Enter WiFi Password");
     lv_obj_set_width(label, CYD_SCREEN_WIDTH_PX - CYD_SCREEN_GAP_PX * 2);
 
@@ -92,7 +92,7 @@ void wifi_init_inner(){
     if (global_config.wifiConfigured){
         WiFi.begin(global_config.wifiSSID, global_config.wifiPassword);
         
-        lv_obj_t * label = lv_label_create_ex(lv_scr_act());
+        lv_obj_t * label = lv_label_create(lv_scr_act());
         lv_label_set_text(label, "Connecting to WiFi");
         lv_obj_align(label, LV_ALIGN_CENTER, 0, 0);
 
@@ -101,14 +101,14 @@ void wifi_init_inner(){
         lv_obj_set_height(resetBtn, CYD_SCREEN_MIN_BUTTON_HEIGHT_PX);
         lv_obj_align(resetBtn, LV_ALIGN_CENTER, 0, CYD_SCREEN_GAP_PX + CYD_SCREEN_MIN_BUTTON_HEIGHT_PX);
 
-        label = lv_label_create_ex(resetBtn);
+        label = lv_label_create(resetBtn);
         lv_label_set_text(label, "Reset");
         lv_obj_center(label);
 
         return;
     } 
 
-    lv_obj_t * label = lv_label_create_ex(lv_scr_act());
+    lv_obj_t * label = lv_label_create(lv_scr_act());
     lv_label_set_text(label, "Scanning for networks...");
     lv_obj_align(label, LV_ALIGN_CENTER, 0, 0);
 
@@ -127,14 +127,14 @@ void wifi_init_inner(){
     lv_obj_set_size(top_row, CYD_SCREEN_WIDTH_PX - CYD_SCREEN_GAP_PX * 2, LV_SIZE_CONTENT);
     lv_layout_flex_row(top_row, LV_FLEX_ALIGN_SPACE_BETWEEN);
 
-    label = lv_label_create_ex(top_row);
+    label = lv_label_create(top_row);
     lv_label_set_text(label, "Select a network");
 
     lv_obj_t * refreshBtn = lv_btn_create(top_row);
     lv_obj_add_event_cb(refreshBtn, reset_btn_event_handler, LV_EVENT_ALL, NULL);
     lv_obj_set_size(refreshBtn, CYD_SCREEN_MIN_BUTTON_WIDTH_PX, CYD_SCREEN_MIN_BUTTON_HEIGHT_PX);
 
-    label = lv_label_create_ex(refreshBtn);
+    label = lv_label_create(refreshBtn);
     lv_label_set_text(label, LV_SYMBOL_REFRESH);
     lv_obj_center(label);
 

--- a/ci.py
+++ b/ci.py
@@ -32,6 +32,20 @@ def get_manifest(base_path : str, device_name : str):
         ]
     }
 
+def extract_commit() -> str:
+    git_describe_output = subprocess.run(["git", "describe", "--tags"], stdout=subprocess.PIPE, text=True, check=True).stdout.strip()
+    return git_describe_output.split("-")[0]
+
+repo_version = extract_commit()
+configurations = []
+
+def add_configuration(board : str):
+    configurations.append({
+        "Board": board,
+        "Version": repo_version,
+        "URL": f"https://suchmememanyskill.github.io/CYD-Klipper/out/{board}/firmware.bin"
+    })
+
 if os.path.exists("out"):
     shutil.rmtree("out")
 
@@ -54,5 +68,10 @@ for port in CYD_PORTS:
     with open(f"./_site/{port}.json", "w") as f:
         json.dump(get_manifest(port_path, port), f)
 
+    add_configuration(port)
+
 os.chdir(BASE_DIR)
 shutil.copytree("./out", "./_site/out")
+
+with open("./_site/OTA.json", "w") as f:
+    json.dump({"Configurations": configurations}, f)


### PR DESCRIPTION
-- WARNING: THIS UPDATE WILL WIPE YOUR CONFIGURATION --

- Fix up CI builds
- increase SPI frequency for 3.5" model (so the screen is more responsive)
- Fix up touchscreen calibration on 2.8" (#11)
    - This does sadly require a configuration wipe
- Font code refactoring
- Fix up temperature keyboard entry
- Implement OTA updates (#25)
    - When there's an update available, in the settings an update button will be displayed. Pressing it will update the screen
    - An auto update toggle has been added in the settings that makes the screen update right after connecting to wifi