### PR TITLE
Fix frequent null-pointer errors

### DIFF
--- a/CYD-Klipper/src/core/data_setup.cpp
+++ b/CYD-Klipper/src/core/data_setup.cpp
@@ -229,7 +229,11 @@ void fetch_printer_data()
 
                 const char *state = status["print_stats"]["state"];
 
-                if (strcmp(state, "printing") == 0)
+                if (state == nullptr)
+                {
+                    printer_state = PRINTER_STATE_ERROR;
+                }
+                else if (strcmp(state, "printing") == 0)
                 {
                     printer_state = PRINTER_STATE_PRINTING;
                 }


### PR DESCRIPTION
I was frequently seeing the following and a reboot:

```
Guru Meditation Error: Core  0 panic'ed (LoadProhibited). Exception was unhandled.

Core  0 register dump:
PC      : 0x4008ae2d  PS      : 0x00060330  A0      : 0x800d3fd9  A1      : 0x3ffe15f0
A2      : 0x3ffc40e8  A3      : 0x00000000  A4      : 0x000000ff  A5      : 0x0000ff00
A6      : 0x00ff0000  A7      : 0xff000000  A8      : 0x00000000  A9      : 0x3ffe15c0
A10     : 0x3ffc40e8  A11     : 0x3f40035d  A12     : 0x3ffe16a0  A13     : 0x000004b0
A14     : 0x7ff00000  A15     : 0x7ff2c000  SAR     : 0x0000001d  EXCCAUSE: 0x0000001c
EXCVADDR: 0x00000000  LBEG    : 0x4008ae2d  LEND    : 0x4008ae41  LCOUNT  : 0xffffffff

Backtrace: 0x4008ae2a:0x3ffe15f0 0x400d3fd6:0x3ffe1600 0x400d42d3:0x3ffe18f0
````

decoded:

```
0x4008acbc: strcmp at /builds/idf/crosstool-NG/.build/xtensa-esp32-elf/src/newlib/newlib/libc/machine/xtensa/strcmp.S:467
0x400d4145: fetch_printer_data() at /home/user/tmp/CYD-Klipper/CYD-Klipper/src/core/data_setup.cpp:180
0x400d42d3: data_loop_background(void*) at /home/user/tmp/CYD-Klipper/CYD-Klipper/src/core/data_setup.cpp:233 (discriminator 1)
```

Seems like the printer state was frequently ending up as null, so check
for that and return a reasonable response. After applying this patch,
things are stable for me.
