### PR TITLE
Fix segfault on entering IP

### DIFF
--- a/CYD-Klipper/src/ui/ip_setup.cpp
+++ b/CYD-Klipper/src/ui/ip_setup.cpp
@@ -62,6 +62,20 @@ static void keyboard_event_ip_entry(lv_event_t * e) {
     lv_obj_t * ta = lv_event_get_target(e);
     lv_obj_t * kb = (lv_obj_t *)lv_event_get_user_data(e);
 
+    if ((code == LV_EVENT_FOCUSED || code == LV_EVENT_DEFOCUSED) && ta != NULL)
+    {
+        // make sure we alter the keymap before taking actions that might
+        // destroy the keyboard
+        if (lv_obj_has_flag(ta, LV_OBJ_FLAG_USER_1))
+        {
+            lv_keyboard_set_mode(kb, LV_KEYBOARD_MODE_USER_1);
+        }
+        else
+        {
+            lv_keyboard_set_mode(kb, LV_KEYBOARD_MODE_NUMBER);
+        }
+    }
+
     if(code == LV_EVENT_FOCUSED) {
         lv_keyboard_set_textarea(kb, ta);
         lv_obj_clear_flag(kb, LV_OBJ_FLAG_HIDDEN);
@@ -93,15 +107,6 @@ static void keyboard_event_ip_entry(lv_event_t * e) {
     else
     {
         return;
-    }
-
-    if (lv_obj_has_flag(ta, LV_OBJ_FLAG_USER_1))
-    {
-        lv_keyboard_set_mode(kb, LV_KEYBOARD_MODE_USER_1);
-    }
-    else
-    {
-        lv_keyboard_set_mode(kb, LV_KEYBOARD_MODE_NUMBER);
     }
 }
 


### PR DESCRIPTION
On my esp32-3248S035C, after entering the IP address, I was seeing a segfault at ([I decoded this using a quick script I wrote](https://gist.github.com/flaviut/3dbfb937fcfab407e9f2be88728a642d))

```
lv_mem_free at .pio/libdeps/esp32-3248S035C/lvgl/src/misc/lv_mem.c:179
allocate_btn_areas_and_controls at .pio/libdeps/esp32-3248S035C/lvgl/src/widgets/lv_btnmatrix.c:877
lv_btnmatrix_set_map at .pio/libdeps/esp32-3248S035C/lvgl/src/widgets/lv_btnmatrix.c:94
lv_keyboard_update_map at .pio/libdeps/esp32-3248S035C/lvgl/src/extra/widgets/keyboard/lv_keyboard.c:397
lv_keyboard_set_mode at .pio/libdeps/esp32-3248S035C/lvgl/src/extra/widgets/keyboard/lv_keyboard.c:185
keyboard_event_ip_entry(_lv_event_t*) at src/ui/ip_setup.cpp:81
event_send_core at .pio/libdeps/esp32-3248S035C/lvgl/src/core/lv_event.c:467
lv_event_send at .pio/libdeps/esp32-3248S035C/lvgl/src/core/lv_event.c:63
lv_keyboard_def_event_cb at .pio/libdeps/esp32-3248S035C/lvgl/src/extra/widgets/keyboard/lv_keyboard.c:308
event_send_core at .pio/libdeps/esp32-3248S035C/lvgl/src/core/lv_event.c:467
lv_event_send at .pio/libdeps/esp32-3248S035C/lvgl/src/core/lv_event.c:63
lv_btnmatrix_event at .pio/libdeps/esp32-3248S035C/lvgl/src/widgets/lv_btnmatrix.c:520
lv_obj_event_base at .pio/libdeps/esp32-3248S035C/lvgl/src/core/lv_event.c:91 (discriminator 1)
event_send_core at .pio/libdeps/esp32-3248S035C/lvgl/src/core/lv_event.c:458
lv_event_send at .pio/libdeps/esp32-3248S035C/lvgl/src/core/lv_event.c:63
indev_proc_release at .pio/libdeps/esp32-3248S035C/lvgl/src/core/lv_indev.c:970
indev_button_proc at .pio/libdeps/esp32-3248S035C/lvgl/src/core/lv_indev.c:808
lv_timer_exec at .pio/libdeps/esp32-3248S035C/lvgl/src/misc/lv_timer.c:313
set_screen_brightness() at src/core/lv_setup.cpp:191
ip_init() at src/ui/ip_setup.cpp:239
setup() at src/main.cpp:28
loopTask(void*) at /home/user/etc/.platformio/packages/framework-arduinoespressif32/cores/esp32/main.cpp:41
```

This seems to be due to a free-after-free. The solution here is to potentially change the keymap before running the rest of the logic, because the later logic may tear down the context.

This change also only changes the keyboard mode on focus change, to avoid running this code on the many un-related events that this handler gets called for.