### PR TITLE
Bulletproof ci.py

### DIFF
--- a/ci.py
+++ b/ci.py
@@ -81,7 +81,10 @@ for port in CYD_PORTS:
     add_configuration(port)
 
 os.chdir(BASE_DIR)
-shutil.copytree("./out", "./_site/out")
+out_dir = "./_site/out"
+if os.path.exists(out_dir):
+    shutil.rmtree(out_dir)
+shutil.copytree("./out", out_dir)
 
 with open("./_site/OTA.json", "w") as f:
     json.dump({"Configurations": configurations}, f)


### PR DESCRIPTION
Currently `ci.py` will crash at the end if `./_site/out` already exists as `shutil.copytree(...)` does not support overwriting files.

This merge request improves the situation by checking and deleting the directory beforehand if necessary.

---

Thank you for considering the inclusion of this merge request.