### PR TITLE
Add emergency stop and full filename options

### DIFF
--- a/CYD-Klipper/src/conf/global_config.h
+++ b/CYD-Klipper/src/conf/global_config.h
@@ -70,6 +70,7 @@ typedef struct _GLOBAL_CONFIG {
             bool display_mode : 1; // Driver specifc usage. Currently only used on ESP32-2432S028R to fix the screen on the usb-c model
             bool disable_m117_messaging : 1;
             bool sort_macros : 1;
+            bool show_estop : 1;
         };
     };
 

--- a/CYD-Klipper/src/conf/global_config.h
+++ b/CYD-Klipper/src/conf/global_config.h
@@ -71,6 +71,7 @@ typedef struct _GLOBAL_CONFIG {
             bool disable_m117_messaging : 1;
             bool sort_macros : 1;
             bool show_estop : 1;
+            bool full_filenames : 1;
         };
     };
 

--- a/CYD-Klipper/src/core/data_setup.cpp
+++ b/CYD-Klipper/src/core/data_setup.cpp
@@ -56,6 +56,21 @@ void send_gcode(bool wait, const char *gcode)
     }
 }
 
+void send_estop()
+{
+    LOG_LN("Sending estop");
+
+    SETUP_HTTP_CLIENT_FULL("/printer/emergency_stop", false, 5000);
+    try
+    {
+        client.GET();
+    }
+    catch (...)
+    {
+        LOG_LN("Failed to send estop");
+    }
+}
+
 int get_slicer_time_estimate_s()
 {
     if (printer.state == PRINTER_STATE_IDLE)

--- a/CYD-Klipper/src/core/data_setup.h
+++ b/CYD-Klipper/src/core/data_setup.h
@@ -54,6 +54,7 @@ extern int klipper_request_consecutive_fail_count;
 
 void data_loop();
 void data_setup();
+void send_estop();
 void send_gcode(bool wait, const char* gcode);
 void move_printer(const char* axis, float amount, bool relative);
 

--- a/CYD-Klipper/src/ui/panels/files_panel.cpp
+++ b/CYD-Klipper/src/ui/panels/files_panel.cpp
@@ -94,7 +94,11 @@ void files_panel_init(lv_obj_t* panel){
     int count = 0;
     while (files != NULL && files->name != NULL && count <= 20){
         lv_obj_t * btn = lv_list_add_btn(list, LV_SYMBOL_FILE, files->name);
-        lv_obj_set_style_bg_opa(btn, LV_OPA_TRANSP, 0); 
+        lv_obj_set_style_bg_opa(btn, LV_OPA_TRANSP, 0);
+              
+        if (global_config.full_filenames){
+            lv_label_set_long_mode(lv_obj_get_child(btn, 1), LV_LABEL_LONG_WRAP);
+        }
         lv_obj_add_event_cb(btn, btn_print_file_verify, LV_EVENT_CLICKED, (void*)files);
 
         files += 1;

--- a/CYD-Klipper/src/ui/panels/progress_panel.cpp
+++ b/CYD-Klipper/src/ui/panels/progress_panel.cpp
@@ -69,6 +69,11 @@ static void btn_click_resume(lv_event_t * e){
     send_gcode(true, "RESUME");
 }
 
+static void btn_click_estop(lv_event_t * e){
+    send_estop();
+    send_gcode(false, "M112");
+}
+
 void progress_panel_init(lv_obj_t* panel){
     auto panel_width = CYD_SCREEN_PANEL_WIDTH_PX - CYD_SCREEN_GAP_PX * 3;
     const auto button_size_mult = 1.3f;
@@ -172,5 +177,19 @@ void progress_panel_init(lv_obj_t* panel){
         lv_obj_set_style_text_font(label, &CYD_SCREEN_FONT_SMALL, 0);
         lv_obj_add_event_cb(label, update_printer_data_stats, LV_EVENT_MSG_RECEIVED, NULL);
         lv_msg_subsribe_obj(DATA_PRINTER_DATA, label, NULL);
+    }
+
+    if (global_config.show_estop)
+    {
+        lv_obj_t * btn = lv_btn_create(panel);
+        lv_obj_set_flex_grow(btn, 1);
+        lv_obj_add_event_cb(btn, btn_click_estop, LV_EVENT_CLICKED, NULL);
+        lv_obj_set_height(btn, CYD_SCREEN_MIN_BUTTON_HEIGHT_PX);
+        
+        lv_obj_align(btn, LV_ALIGN_TOP_LEFT, CYD_SCREEN_GAP_PX, CYD_SCREEN_GAP_PX);
+
+        label = lv_label_create(btn);
+        lv_label_set_text(label, "EMERGENCY STOP");
+        lv_obj_center(label);
     }
 }

--- a/CYD-Klipper/src/ui/panels/progress_panel.cpp
+++ b/CYD-Klipper/src/ui/panels/progress_panel.cpp
@@ -78,44 +78,32 @@ void progress_panel_init(lv_obj_t* panel){
     auto panel_width = CYD_SCREEN_PANEL_WIDTH_PX - CYD_SCREEN_GAP_PX * 3;
     const auto button_size_mult = 1.3f;
 
-    lv_obj_t * center_panel = lv_create_empty_panel(panel);
-    lv_obj_set_size(center_panel, panel_width, LV_SIZE_CONTENT);
-    lv_layout_flex_column(center_panel);
-
-    if (get_current_printer_config()->show_stats_on_progress_panel == SHOW_STATS_ON_PROGRESS_PANEL_ALL)
-    {
-        lv_obj_align(center_panel, LV_ALIGN_TOP_MID, 0, CYD_SCREEN_GAP_PX);
-    }
-    else 
-    {
-        lv_obj_align(center_panel, LV_ALIGN_CENTER, 0, 0);
-    }
-
-    
-    if (get_current_printer_config()->show_stats_on_progress_panel == SHOW_STATS_ON_PROGRESS_PANEL_LAYER)
-    {
-        lv_obj_t * label = lv_label_create(panel);
-        lv_obj_align(label, LV_ALIGN_TOP_MID, 0, CYD_SCREEN_GAP_PX);
-        lv_obj_set_style_text_font(label, &CYD_SCREEN_FONT_SMALL, 0);
-        lv_obj_add_event_cb(label, update_printer_data_stats, LV_EVENT_MSG_RECEIVED, NULL);
-        lv_msg_subsribe_obj(DATA_PRINTER_DATA, label, NULL);
-    }
-
     // Emergency Stop
     if (global_config.show_estop){
-        lv_obj_t * btn = lv_btn_create(center_panel);
+        lv_obj_t * btn = lv_btn_create(panel);
         lv_obj_add_event_cb(btn, btn_click_estop, LV_EVENT_CLICKED, NULL);
+        
         lv_obj_set_height(btn, CYD_SCREEN_MIN_BUTTON_HEIGHT_PX);
-        lv_obj_align(btn, LV_ALIGN_CENTER, LV_ALIGN_CENTER, CYD_SCREEN_GAP_PX);
-
-        lv_obj_set_style_bg_opa(btn, LV_OPA_TRANSP, LV_PART_MAIN);
-        lv_obj_set_style_outline_width(btn, 1, LV_PART_MAIN);
-        lv_obj_set_style_outline_color(btn, lv_color_hex(0xFF0000), LV_PART_MAIN);
-        lv_obj_set_style_text_color(btn, lv_color_hex(0xFF0000), LV_PART_MAIN);
+        lv_obj_align(btn, LV_ALIGN_TOP_MID, 0, CYD_SCREEN_GAP_PX);
+        lv_obj_set_style_bg_color(btn, lv_color_hex(0xFF0000), LV_PART_MAIN);
 
         lv_obj_t * label = lv_label_create(btn);
         lv_label_set_text(label, LV_SYMBOL_POWER " EMERGENCY STOP");
         lv_obj_center(label);
+    }
+
+    lv_obj_t * center_panel = lv_create_empty_panel(panel);
+    lv_obj_set_size(center_panel, panel_width, LV_SIZE_CONTENT);
+    lv_layout_flex_column(center_panel);
+
+    // Only align progress bar to top mid if necessary to make room for all extras
+    if (get_current_printer_config()->show_stats_on_progress_panel == SHOW_STATS_ON_PROGRESS_PANEL_ALL && CYD_SCREEN_HEIGHT_PX <= 320)
+    {
+        lv_obj_align(center_panel, LV_ALIGN_TOP_MID, 0, CYD_SCREEN_MIN_BUTTON_HEIGHT_PX+(3 * CYD_SCREEN_GAP_PX));
+    }
+    else 
+    {
+        lv_obj_align(center_panel, LV_ALIGN_CENTER, 0, 0);
     }
 
     // Filename
@@ -188,7 +176,7 @@ void progress_panel_init(lv_obj_t* panel){
     lv_obj_align(btn, LV_ALIGN_BOTTOM_RIGHT, -2 * CYD_SCREEN_GAP_PX - CYD_SCREEN_MIN_BUTTON_WIDTH_PX * button_size_mult, -1 * CYD_SCREEN_GAP_PX);
     lv_obj_set_size(btn, CYD_SCREEN_MIN_BUTTON_WIDTH_PX * button_size_mult, CYD_SCREEN_MIN_BUTTON_HEIGHT_PX * button_size_mult);
 
-    if (get_current_printer_config()->show_stats_on_progress_panel >= SHOW_STATS_ON_PROGRESS_PANEL_PARTIAL)
+    if (get_current_printer_config()->show_stats_on_progress_panel > SHOW_STATS_ON_PROGRESS_PANEL_NONE)
     {
         label = lv_label_create(panel);
         lv_obj_align(label, LV_ALIGN_BOTTOM_LEFT, CYD_SCREEN_GAP_PX, -1 * CYD_SCREEN_GAP_PX);

--- a/CYD-Klipper/src/ui/panels/progress_panel.cpp
+++ b/CYD-Klipper/src/ui/panels/progress_panel.cpp
@@ -101,10 +101,28 @@ void progress_panel_init(lv_obj_t* panel){
         lv_msg_subsribe_obj(DATA_PRINTER_DATA, label, NULL);
     }
 
+    // Emergency Stop
+    if (global_config.show_estop){
+        lv_obj_t * btn = lv_btn_create(center_panel);
+        lv_obj_add_event_cb(btn, btn_click_estop, LV_EVENT_CLICKED, NULL);
+        lv_obj_set_height(btn, CYD_SCREEN_MIN_BUTTON_HEIGHT_PX);
+        lv_obj_align(btn, LV_ALIGN_CENTER, LV_ALIGN_CENTER, CYD_SCREEN_GAP_PX);
+
+        lv_obj_set_style_bg_opa(btn, LV_OPA_TRANSP, LV_PART_MAIN);
+        lv_obj_set_style_outline_width(btn, 1, LV_PART_MAIN);
+        lv_obj_set_style_outline_color(btn, lv_color_hex(0xFF0000), LV_PART_MAIN);
+        lv_obj_set_style_text_color(btn, lv_color_hex(0xFF0000), LV_PART_MAIN);
+
+        lv_obj_t * label = lv_label_create(btn);
+        lv_label_set_text(label, LV_SYMBOL_POWER " EMERGENCY STOP");
+        lv_obj_center(label);
+    }
+
     // Filename
     lv_obj_t * label = lv_label_create(center_panel);
     lv_label_set_text(label, printer.print_filename);
-    lv_label_set_long_mode(label, LV_LABEL_LONG_SCROLL_CIRCULAR);
+    if (global_config.full_filenames) lv_label_set_long_mode(label, LV_LABEL_LONG_WRAP);
+    else lv_label_set_long_mode(label, LV_LABEL_LONG_SCROLL_CIRCULAR);
     lv_obj_set_width(label, panel_width);
     
     // Progress Bar
@@ -177,19 +195,5 @@ void progress_panel_init(lv_obj_t* panel){
         lv_obj_set_style_text_font(label, &CYD_SCREEN_FONT_SMALL, 0);
         lv_obj_add_event_cb(label, update_printer_data_stats, LV_EVENT_MSG_RECEIVED, NULL);
         lv_msg_subsribe_obj(DATA_PRINTER_DATA, label, NULL);
-    }
-
-    if (global_config.show_estop)
-    {
-        lv_obj_t * btn = lv_btn_create(panel);
-        lv_obj_set_flex_grow(btn, 1);
-        lv_obj_add_event_cb(btn, btn_click_estop, LV_EVENT_CLICKED, NULL);
-        lv_obj_set_height(btn, CYD_SCREEN_MIN_BUTTON_HEIGHT_PX);
-        
-        lv_obj_align(btn, LV_ALIGN_TOP_LEFT, CYD_SCREEN_GAP_PX, CYD_SCREEN_GAP_PX);
-
-        label = lv_label_create(btn);
-        lv_label_set_text(label, "EMERGENCY STOP");
-        lv_obj_center(label);
     }
 }

--- a/CYD-Klipper/src/ui/panels/settings_panel.cpp
+++ b/CYD-Klipper/src/ui/panels/settings_panel.cpp
@@ -117,6 +117,13 @@ static void sort_macros_switch(lv_event_t* e){
     write_global_config();
 }
 
+static void show_estop_switch(lv_event_t* e){
+    auto state = lv_obj_get_state(lv_event_get_target(e));
+    bool checked = (state & LV_STATE_CHECKED == LV_STATE_CHECKED);
+    global_config.show_estop = checked;
+    write_global_config();
+}
+
 static void rotate_screen_switch(lv_event_t* e){
     auto state = lv_obj_get_state(lv_event_get_target(e));
     bool checked = (state & LV_STATE_CHECKED == LV_STATE_CHECKED);
@@ -217,6 +224,7 @@ void settings_section_behaviour(lv_obj_t* panel)
             : "Calls FILAMENT_RETRACT and\nFILAMENT_EXTRUDE in temperature menu\nwhen enabled");
 
     lv_create_custom_menu_switch("Sort Macros A->Z", panel, sort_macros_switch, global_config.sort_macros);
+    lv_create_custom_menu_switch("Show Emergency Stop", panel, show_estop_switch, global_config.show_estop);
 }
 
 void settings_section_device(lv_obj_t* panel)

--- a/CYD-Klipper/src/ui/panels/settings_panel.cpp
+++ b/CYD-Klipper/src/ui/panels/settings_panel.cpp
@@ -124,6 +124,13 @@ static void show_estop_switch(lv_event_t* e){
     write_global_config();
 }
 
+static void full_filenames_switch(lv_event_t* e){
+    auto state = lv_obj_get_state(lv_event_get_target(e));
+    bool checked = (state & LV_STATE_CHECKED == LV_STATE_CHECKED);
+    global_config.full_filenames = checked;
+    write_global_config();
+}
+
 static void rotate_screen_switch(lv_event_t* e){
     auto state = lv_obj_get_state(lv_event_get_target(e));
     bool checked = (state & LV_STATE_CHECKED == LV_STATE_CHECKED);
@@ -225,6 +232,7 @@ void settings_section_behaviour(lv_obj_t* panel)
 
     lv_create_custom_menu_switch("Sort Macros A->Z", panel, sort_macros_switch, global_config.sort_macros);
     lv_create_custom_menu_switch("Show Emergency Stop", panel, show_estop_switch, global_config.show_estop);
+    lv_create_custom_menu_switch("Show Full Filenames", panel, full_filenames_switch, global_config.full_filenames);
 }
 
 void settings_section_device(lv_obj_t* panel)


### PR DESCRIPTION
Both are optional using global configs.

Full filename removes scrolling the filename when showing 1) the list of printable items and 2) the current printing gcode.

Emergency stop hits the proper estop endpoint, as well as sending the `M112` command for good measure.
https://moonraker.readthedocs.io/en/latest/web_api/#emergency-stop

![PXL_20240814_174552319 MP](https://github.com/user-attachments/assets/a83b4688-f50a-4c0a-9bfc-a072b1d84b2a)
