### PR TITLE
platfromio: Update LovyanGFX from 1.2.0 to 1.2.7

### DIFF
--- a/CYD-Klipper/platformio.ini
+++ b/CYD-Klipper/platformio.ini
@@ -111,7 +111,7 @@ board = esp32-CROWPANEL-35C
 lib_deps =
 	SPI
 	https://github.com/suchmememanyskill/lvgl
-	https://github.com/lovyan03/LovyanGFX@1.2.0
+	https://github.com/lovyan03/LovyanGFX@1.2.7
 	bblanchon/ArduinoJson@^7.0.0
 	plageoj/UrlEncode@^1.0.1
 	knolleary/PubSubClient@^2.8


### PR DESCRIPTION
platfromio: Update LovyanGFX from 1.2.0 to 1.2.7

Build was failing for older version of LovyanGFX for esp32-CROWPANEL-35C issue [issue #197](https://github.com/suchmememanyskill/CYD-Klipper/issues/197)

```bash
PackageException: Package version 1.2.7+sha.5438181 doesn't satisfy requirements 1.2.0 based on PackageMetadata <type=library name=LovyanGFX version=1.2.7+sha.5438181 spec={'owner': None, 'id': None, 'name': 'LovyanGFX', 'requirements': '1.2.0', 'uri': 'git+https://github.com/lovyan03/LovyanGFX'}
Traceback (most recent call last):
  File "D:\a\CYD-Klipper\CYD-Klipper\ci.py", line 80, in <module>
    subprocess.run(["pio", "run", "-e", port], check=True)
  File "C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\subprocess.py", line 528, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['pio', 'run', '-e', 'esp32-CROWPANEL-35C']' returned non-zero exit status 1.
Error: Process completed with exit code 1.```

The following patch updates the GFX lib from 1.2.0 to 1.2.7
